### PR TITLE
feat: extend translation export options by adding csv way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .credentials.json
 dist
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,143 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fast-csv/parse": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-5.0.2.tgz",
+      "integrity": "sha512-gMu1Btmm99TP+wc0tZnlH30E/F1Gw1Tah3oMDBHNPe9W8S68ixVHjt89Wg5lh7d9RuQMtwN+sGl5kxR891+fzw==",
+      "dependencies": {
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@googleapis/drive": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/drive/-/drive-11.0.0.tgz",
+      "integrity": "sha512-vhkl6/MZ8k5h5XOyenWOD4ys+SNdb8wKYvzU6OBGFx/TzJyHRm4JwgvE8uVDFU6efzNRS0mOiNRfY6nrmHOTtg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@googleapis/drive/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@googleapis/drive/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@googleapis/drive/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@googleapis/drive/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@googleapis/drive/node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@googleapis/drive/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@googleapis/drive/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@googleapis/drive/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -795,6 +932,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babelsheet2": {
@@ -1790,15 +1938,16 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -2033,6 +2182,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/google-p12-pem": {
@@ -2758,10 +2916,40 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng=="
+    },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -4207,6 +4395,66 @@
         "typescript": "^4.5.4"
       }
     },
+    "packages/cli/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "packages/cli/node_modules/babelsheet2-reader": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/babelsheet2-reader/-/babelsheet2-reader-0.0.8.tgz",
+      "integrity": "sha512-Bn3Cc7YFOBlf5KXwHlqsxcso/+itq37B+6K6eILGXHzdZc41ykki5pVuhuTH1q7OYtmVqqnpVzfvKy8VhdlQ+A==",
+      "license": "MIT",
+      "dependencies": {
+        "google-spreadsheet": "^4.1.1"
+      },
+      "peerDependencies": {
+        "rxjs": ">=6.0.0"
+      }
+    },
+    "packages/cli/node_modules/babelsheet2-reader/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/cli/node_modules/babelsheet2-reader/node_modules/google-spreadsheet": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/google-spreadsheet/-/google-spreadsheet-4.1.4.tgz",
+      "integrity": "sha512-v6Bi7LIB/2E3+/XKmk11Qih2U0KpENSZuLSHOi8XoRDna/Tx8WYCZeEUTF60eucaELGLWC8GSepb0Cbkr3aXfg==",
+      "license": "Unlicense",
+      "dependencies": {
+        "axios": "^1.7.7",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "google-auth-library": "^8.8.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "google-auth-library": {
+          "optional": true
+        }
+      }
+    },
     "packages/cli/node_modules/babelsheet2/node_modules/babelsheet2-reader": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/babelsheet2-reader/-/babelsheet2-reader-0.0.5.tgz",
@@ -4218,6 +4466,85 @@
       },
       "peerDependencies": {
         "rxjs": ">=6.0.0"
+      }
+    },
+    "packages/cli/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/cli/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/cli/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/cli/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "packages/cli/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "packages/json-writer": {
@@ -4249,9 +4576,11 @@
     },
     "packages/reader": {
       "name": "babelsheet2-reader",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
+        "@fast-csv/parse": "5.0.2",
+        "@googleapis/drive": "11.0.0",
         "google-spreadsheet": "^4.1.1"
       },
       "devDependencies": {
@@ -4288,16 +4617,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "packages/reader/node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
-      "dependencies": {
-        "follow-redirects": "^1.15.4",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/reader/node_modules/gaxios": {
@@ -4447,6 +4766,105 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
       "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
       "dev": true
+    },
+    "@fast-csv/parse": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-5.0.2.tgz",
+      "integrity": "sha512-gMu1Btmm99TP+wc0tZnlH30E/F1Gw1Tah3oMDBHNPe9W8S68ixVHjt89Wg5lh7d9RuQMtwN+sGl5kxR891+fzw==",
+      "requires": {
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "@googleapis/drive": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/drive/-/drive-11.0.0.tgz",
+      "integrity": "sha512-vhkl6/MZ8k5h5XOyenWOD4ys+SNdb8wKYvzU6OBGFx/TzJyHRm4JwgvE8uVDFU6efzNRS0mOiNRfY6nrmHOTtg==",
+      "requires": {
+        "googleapis-common": "^7.0.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+          "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="
+        },
+        "gaxios": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+          "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+          "requires": {
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^7.0.1",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.6.9",
+            "uuid": "^9.0.1"
+          }
+        },
+        "gcp-metadata": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+          "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+          "requires": {
+            "gaxios": "^6.1.1",
+            "google-logging-utils": "^0.0.2",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "9.15.1",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+          "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "gaxios": "^6.1.1",
+            "gcp-metadata": "^6.1.0",
+            "gtoken": "^7.0.0",
+            "jws": "^4.0.0"
+          }
+        },
+        "googleapis-common": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+          "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+          "requires": {
+            "extend": "^3.0.2",
+            "gaxios": "^6.0.3",
+            "google-auth-library": "^9.7.0",
+            "qs": "^6.7.0",
+            "url-template": "^2.0.8",
+            "uuid": "^9.0.0"
+          }
+        },
+        "gtoken": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+          "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+          "requires": {
+            "gaxios": "^6.0.0",
+            "jws": "^4.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+          "requires": {
+            "agent-base": "^7.1.2",
+            "debug": "4"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -4917,6 +5335,16 @@
       "integrity": "sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg==",
       "dev": true
     },
+    "axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "requires": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "babelsheet2": {
       "version": "file:packages/cli",
       "requires": {
@@ -4934,6 +5362,104 @@
         "open": "^8.4.0",
         "rxjs": "^7.5.1",
         "typescript": "^4.5.4"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+          "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+          "optional": true,
+          "peer": true
+        },
+        "babelsheet2-reader": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/babelsheet2-reader/-/babelsheet2-reader-0.0.8.tgz",
+          "integrity": "sha512-Bn3Cc7YFOBlf5KXwHlqsxcso/+itq37B+6K6eILGXHzdZc41ykki5pVuhuTH1q7OYtmVqqnpVzfvKy8VhdlQ+A==",
+          "requires": {
+            "google-spreadsheet": "^4.1.1"
+          },
+          "dependencies": {
+            "google-auth-library": {
+              "version": "9.15.1",
+              "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+              "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+              "optional": true,
+              "peer": true,
+              "requires": {
+                "base64-js": "^1.3.0",
+                "ecdsa-sig-formatter": "^1.0.11",
+                "gaxios": "^6.1.1",
+                "gcp-metadata": "^6.1.0",
+                "gtoken": "^7.0.0",
+                "jws": "^4.0.0"
+              }
+            },
+            "google-spreadsheet": {
+              "version": "4.1.4",
+              "resolved": "https://registry.npmjs.org/google-spreadsheet/-/google-spreadsheet-4.1.4.tgz",
+              "integrity": "sha512-v6Bi7LIB/2E3+/XKmk11Qih2U0KpENSZuLSHOi8XoRDna/Tx8WYCZeEUTF60eucaELGLWC8GSepb0Cbkr3aXfg==",
+              "requires": {
+                "axios": "^1.7.7",
+                "lodash": "^4.17.21"
+              }
+            }
+          }
+        },
+        "gaxios": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+          "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^7.0.1",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.6.9",
+            "uuid": "^9.0.1"
+          }
+        },
+        "gcp-metadata": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+          "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "gaxios": "^6.1.1",
+            "google-logging-utils": "^0.0.2",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "gtoken": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+          "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "gaxios": "^6.0.0",
+            "jws": "^4.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "agent-base": "^7.1.2",
+            "debug": "4"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+          "optional": true,
+          "peer": true
+        }
       }
     },
     "babelsheet2-json-writer": {
@@ -4961,6 +5487,8 @@
     "babelsheet2-reader": {
       "version": "file:packages/reader",
       "requires": {
+        "@fast-csv/parse": "5.0.2",
+        "@googleapis/drive": "11.0.0",
         "@types/node": "^17.0.2",
         "@types/tape": "^4.13.2",
         "@typescript-eslint/eslint-plugin": "^5.8.0",
@@ -4989,16 +5517,6 @@
           "peer": true,
           "requires": {
             "debug": "^4.3.4"
-          }
-        },
-        "axios": {
-          "version": "1.6.7",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-          "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
-          "requires": {
-            "follow-redirects": "^1.15.4",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
           }
         },
         "gaxios": {
@@ -5767,9 +6285,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -5924,6 +6442,11 @@
         "jws": "^4.0.0",
         "lru-cache": "^6.0.0"
       }
+    },
+    "google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="
     },
     "google-p12-pem": {
       "version": "3.1.4",
@@ -6377,9 +6900,39 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+    },
+    "lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="
+    },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+    },
+    "lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng=="
+    },
+    "lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA=="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
     "log-symbols": {
       "version": "4.1.0",

--- a/packages/reader/package.json
+++ b/packages/reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babelsheet2-reader",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Rx.js observable that parses Babelsheet-formatted Google Spreadsheet",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,6 +19,8 @@
   "author": "The Software House",
   "license": "MIT",
   "dependencies": {
+    "@fast-csv/parse": "5.0.2",
+    "@googleapis/drive": "11.0.0",
     "google-spreadsheet": "^4.1.1"
   },
   "peerDependencies": {

--- a/packages/reader/src/csv-rows-iterator.ts
+++ b/packages/reader/src/csv-rows-iterator.ts
@@ -1,0 +1,70 @@
+import { google } from 'googleapis';
+import { parse } from '@fast-csv/parse';
+import { EOL } from 'node:os';
+import { Credentials } from './types';
+
+export type DriveCsvSourceConfig = {
+  spreadsheetId: string;
+  credentials: Credentials;
+};
+
+// eslint-disable-next-line max-len
+async function exportSpreadsheetToCSV(spreadsheetId: string, credentials: Credentials): Promise<string> {
+  const auth = new google.auth.JWT({
+    email: credentials.client_email,
+    key: credentials.private_key,
+    scopes: ['https://www.googleapis.com/auth/drive'],
+  });
+
+  const drive = google.drive({
+    version: 'v3',
+    auth,
+  });
+  const { data } = await drive.files.export({
+    fileId: spreadsheetId,
+    mimeType: 'text/csv',
+  });
+  if (typeof data !== 'string') {
+    throw new Error('Type of exported sheet is different than string');
+  }
+  return data;
+}
+
+export async function parseCsv(csvString: string): Promise<(string|null)[][]> {
+  const csvStringRows = csvString.split('\r\n');
+  const headersRowIndex = csvStringRows.findIndex((csvRow) => csvRow.startsWith('###'));
+  const rowsWithHeaders = csvStringRows.slice(headersRowIndex);
+
+  return new Promise((resolve, reject) => {
+    const rows: (string|null)[][] = [];
+
+    const stream = parse()
+      .on('error', (err) => {
+        console.error(err);
+        reject(err);
+      })
+      .on('data', (row: string[]) => rows.push(row.map((cell) => (cell.trim() === '' ? null : cell))))
+      .on('end', () => resolve(rows));
+    stream.write(rowsWithHeaders.join(EOL));
+    stream.end();
+  });
+}
+
+export async function* csvRowsIterator({ spreadsheetId, credentials }: DriveCsvSourceConfig) {
+  const csv = await exportSpreadsheetToCSV(spreadsheetId, credentials);
+
+  let rows: (string|null)[][] = [];
+  try {
+    rows = await parseCsv(csv);
+  } catch (e) {
+    throw new Error('Encountered an error when parsing csv');
+  }
+
+  if (!rows.length) {
+    throw new Error('No rows found after parsing csv');
+  }
+
+  for (let i = 0; i < rows.length; i++) {
+    yield rows[i];
+  }
+}

--- a/packages/reader/src/index.ts
+++ b/packages/reader/src/index.ts
@@ -11,8 +11,10 @@ import {
   mergeMap,
   mergeAll,
 } from 'rxjs/operators';
+import { csvRowsIterator } from './csv-rows-iterator';
+import { FromBabelsheetConfig } from './types';
 import {
-  CellValue, Row, spreadsheetRowsIterator, SpreadsheetSourceConfig,
+  CellValue, Row, spreadsheetRowsIterator,
 } from './spreadsheet-rows-iterator';
 
 export type TranslationEntry = {
@@ -24,11 +26,16 @@ export type TranslationEntry = {
 
 const END_AFTER_EMPTY_ROWS_COUNT = 10;
 
+export { FromBabelsheetConfig };
+
 // eslint-disable-next-line operator-linebreak
 export const fromBabelsheet = //
-  (config: SpreadsheetSourceConfig): Observable<TranslationEntry> => defer(
+  (config: FromBabelsheetConfig): Observable<TranslationEntry> => defer(
     async () => {
-      const rowsIterator = spreadsheetRowsIterator(config);
+      const { isUsingCsvExport, ...commonConfig } = config;
+      const rowsIterator = isUsingCsvExport
+        ? csvRowsIterator(commonConfig)
+        : spreadsheetRowsIterator(commonConfig);
 
       // Header row parsing
       let headerRow: Row;

--- a/packages/reader/src/spreadsheet-rows-iterator.ts
+++ b/packages/reader/src/spreadsheet-rows-iterator.ts
@@ -1,11 +1,7 @@
 import { JWT } from 'google-auth-library';
-import type { GoogleSpreadsheetCellErrorValue } from "google-spreadsheet";
+import type { GoogleSpreadsheetCellErrorValue } from 'google-spreadsheet';
 import { GoogleSpreadsheet } from 'google-spreadsheet';
-
-export type Credentials = {
-  client_email?: string;
-  private_key?: string;
-}
+import { Credentials } from './types';
 
 export type SpreadsheetSourceConfig = {
   spreadsheetId: string;
@@ -27,7 +23,7 @@ export async function* spreadsheetRowsIterator({
   const document = new GoogleSpreadsheet(spreadsheetId, new JWT({
     email: credentials.client_email,
     key: credentials.private_key,
-    scopes: ['https://www.googleapis.com/auth/spreadsheets']
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
   }));
 
   await document.loadInfo();

--- a/packages/reader/src/types.ts
+++ b/packages/reader/src/types.ts
@@ -1,0 +1,21 @@
+export type Credentials = {
+  client_email?: string;
+  private_key?: string;
+}
+
+type UsingSheetsAPI = {
+  sheetIndex?: number;
+  /** @experimental */
+  isUsingCsvExport?: false;
+}
+
+type UsingDriveCsvAPI = {
+  sheetIndex?: never;
+  /** @experimental */
+  isUsingCsvExport: true;
+}
+
+export type FromBabelsheetConfig = (UsingSheetsAPI | UsingDriveCsvAPI) &{
+  spreadsheetId: string;
+  credentials: Credentials;
+}

--- a/packages/reader/tests/csv-rows-iterator.test.ts
+++ b/packages/reader/tests/csv-rows-iterator.test.ts
@@ -1,0 +1,60 @@
+import test = require('tape');
+import { parseCsv } from '../src/csv-rows-iterator';
+
+test('parseCsv', async () => {
+  test('parses csv correctly for "CRLF" end of line', async (t) => {
+    const result = await parseCsv(
+      [
+        '###,>>>,>>>,>>>,>>>',
+        ',,,SOME,KEY',
+      ].join('\r\n'),
+    );
+
+    t.deepEqual(result, [
+      ['###', '>>>', '>>>', '>>>', '>>>'],
+      [null, null, null, 'SOME', 'KEY'],
+    ]);
+  });
+
+  test('parses csv correctly for "LF" end of line', async (t) => {
+    const result = await parseCsv(
+      [
+        '###,>>>,>>>,>>>,>>>',
+        ',,,SOME,KEY',
+      ].join('\n'),
+    );
+
+    t.deepEqual(result, [
+      ['###', '>>>', '>>>', '>>>', '>>>'],
+      [null, null, null, 'SOME', 'KEY'],
+    ]);
+  });
+
+  test('parses csv correctly for multi-line cells escaped with quotes', async (t) => {
+    const result = await parseCsv(
+      [
+        '###,>>>,>>>,>>>,>>>',
+        ',,,"SOME\nTHING",KEY',
+      ].join('\r\n'),
+    );
+
+    t.deepEqual(result, [
+      ['###', '>>>', '>>>', '>>>', '>>>'],
+      [null, null, null, 'SOME\nTHING', 'KEY'],
+    ]);
+  });
+
+  test('parses csv correctly for irregular amount of columns', async (t) => {
+    const result = await parseCsv(
+      [
+        '###,>>>,>>>',
+        ',  ,,SOME,KEY',
+      ].join('\r\n'),
+    );
+
+    t.deepEqual(result, [
+      ['###', '>>>', '>>>'],
+      [null, null, null, 'SOME', 'KEY'],
+    ]);
+  });
+});


### PR DESCRIPTION
Extending functionality of already existing function `fromBabelsheet`, to be able to use Drive API instead of Sheets API, so that it works faster and it's harder to exceed API quota limits.

There are no breaking changes in default flow.